### PR TITLE
Fix project_setup.py

### DIFF
--- a/project_setup.py
+++ b/project_setup.py
@@ -43,7 +43,7 @@ with open(
 ) as pluginh_file:
     pluginh = pluginh_file.read()
 
-pluginh = pluginh.replace("AuthorName", author)
+pluginh = pluginh.replace("AuthorName", author, 1)
 
 with open(
     os.path.join(cwd, "cmake\\Plugin.h.in"), "w", encoding="utf-8"


### PR DESCRIPTION
This script changes two occurrences of "AuthorName" in Plugin.h.in, making it invalid. 

This change replaces the value of the first occurrence only.